### PR TITLE
Enable syntax highlighting for *.sol

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Mark *.sol files as Solidity to enable syntax highlighting when browsing git.