### PR TITLE
genDummyData script uses unmocked dev deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8870,6 +8870,7 @@
       "version": "github:ethereum/web3.js#f55cfae489f4a28d7205970bd61ed6e2c05de093",
       "from": "github:ethereum/web3.js",
       "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
@@ -8878,7 +8879,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         }
       }
     },

--- a/test/logs/gas-utilization.yaml
+++ b/test/logs/gas-utilization.yaml
@@ -1,6 +1,6 @@
 # Code generated - DO NOT EDIT.
 # Any manual changes may be lost.
-'UFragments:DEPLOYMENT': 1916582
+'UFragments:DEPLOYMENT': 1916646
 'UFragments:transfer(user, 10)': 53843
 'UFragments: approve and transferFrom(user, 10)': 46151
 'UFragments:rebase(1, +100)': 29323


### PR DESCRIPTION
Tested locally and got this output:
```bash
$ npm run blockchain:start gethDev
$ npm run genDummyData

> uFragments@0.0.1 genDummyData /Users/brandon/work/uFragments
> node_modules/truffle/build/cli.bundled.js --network gethDev exec scripts/gen_dummy_data.js

Using network 'gethDev'.

Reporting (Volume=317), (Rate=1455460000000000000), (Supply=1000)
Rebase: SupplyDelta=15 Supply_=1015 Epoch=1
Reporting (Volume=440), (Rate=1375770000000000000), (Supply=1000)
Rebase: SupplyDelta=12 Supply_=1027 Epoch=2
Reporting (Volume=154), (Rate=1565510000000000000), (Supply=1015)
Rebase: SupplyDelta=19 Supply_=1046 Epoch=3
Reporting (Volume=135), (Rate=1361960000000000000), (Supply=1027)
Rebase: SupplyDelta=12 Supply_=1058 Epoch=4
Reporting (Volume=218), (Rate=1416400000000000000), (Supply=1046)
Rebase: SupplyDelta=14 Supply_=1072 Epoch=5
Reporting (Volume=262), (Rate=2327180000000000000), (Supply=1058)
Rebase: SupplyDelta=47 Supply_=1119 Epoch=6
Reporting (Volume=268), (Rate=1698270000000000000), (Supply=1072)
Rebase: SupplyDelta=26 Supply_=1145 Epoch=7
Reporting (Volume=293), (Rate=2112640000000000000), (Supply=1119)
Rebase: SupplyDelta=42 Supply_=1187 Epoch=8
Reporting (Volume=229), (Rate=1787320000000000000), (Supply=1145)
Rebase: SupplyDelta=31 Supply_=1218 Epoch=9
Reporting (Volume=355), (Rate=1272790000000000000), (Supply=1187)
Rebase: SupplyDelta=11 Supply_=1229 Epoch=10
Reporting (Volume=233), (Rate=1400390000000000000), (Supply=1218)
Rebase: SupplyDelta=16 Supply_=1245 Epoch=11
Reporting (Volume=257), (Rate=1636440000000000000), (Supply=1229)
Rebase: SupplyDelta=26 Supply_=1271 Epoch=12
Reporting (Volume=325), (Rate=1058670000000000000), (Supply=1245)
```