### PR TITLE
Removed market-oracle dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1671,7 +1671,8 @@
     },
     "bignumber.js": {
       "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+      "dev": true
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -5818,31 +5819,6 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "market-oracle": {
-      "version": "git+ssh://git@github.com/frgprotocol/market-oracle.git#a8193cd14122f4441bb817df6ab3977a66e93354",
-      "from": "git+ssh://git@github.com/frgprotocol/market-oracle.git",
-      "requires": {
-        "app-root-path": "^2.0.1",
-        "ganache-cli": "^6.1.0",
-        "js-yaml": "^3.11.0",
-        "lodash": "^4.17.5",
-        "openzeppelin-solidity": "1.10.0",
-        "truffle": "4.1.13"
-      },
-      "dependencies": {
-        "web3": {
-          "version": "github:ethereum/web3.js#f55cfae489f4a28d7205970bd61ed6e2c05de093",
-          "from": "github:ethereum/web3.js#f55cfae489f4a28d7205970bd61ed6e2c05de093",
-          "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2-cookies": "^1.1.0",
-            "xmlhttprequest": "*"
-          }
-        }
       }
     },
     "math-random": {

--- a/package.json
+++ b/package.json
@@ -11,20 +11,20 @@
   "bugs": {
     "url": "https://github.com/frgprotocol/uFragments/issues"
   },
-  "license": "ISC",
-  "author": "team@fragments.org",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/frgprotocol/uFragments.git"
   },
+  "license": "ISC",
+  "author": "eng@fragments.org",
   "scripts": {
     "blockchain:start": "scripts/blockchain/runner.sh 1",
     "blockchain:stop": "scripts/blockchain/runner.sh 0",
     "precommit": "scripts/pre-commit.sh",
+    "genDummyData": "node_modules/truffle/build/cli.bundled.js --network gethUnitTest exec scripts/gen_dummy_data.js",
     "lint": "npm run lint:js && npm run lint:sol",
     "lint:js": "node_modules/eslint/bin/eslint.js ./ --cache --fix",
     "lint:sol": "node_modules/solhint/solhint.js contracts/*.sol",
-    "genDummyData": "node_modules/truffle/build/cli.bundled.js --network gethDev exec scripts/gen_dummy_data.js",
     "test": "scripts/test.sh ganacheUnitTest",
     "trackGasUtilization": "npm run blockchain:start && npm run truffle exec test/load/gas_utilization.js save",
     "truffle": "node_modules/truffle/build/cli.bundled.js --network ganacheUnitTest"
@@ -42,7 +42,6 @@
     "ganache-cli": "^6.1.0",
     "js-yaml": "^3.11.0",
     "lodash": "^4.17.5",
-    "market-oracle": "git+ssh://git@github.com/frgprotocol/market-oracle.git",
     "openzeppelin-solidity": "1.10.0",
     "truffle": "4.1.13",
     "web3": "github:ethereum/web3.js"

--- a/scripts/blockchain/index.sh
+++ b/scripts/blockchain/index.sh
@@ -77,12 +77,8 @@ deploy-contracts(){
 
   echo "Removing previous builds"
   rm -rf $DIR/build
-  rm -rf $PROJECT_DIR/node_modules/market-oracle/build
 
   echo "Compiling contracts"
-  $PROJECT_DIR/node_modules/truffle/build/cli.bundled.js \
-    --working-directory $PROJECT_DIR/node_modules/market-oracle \
-    --network $NETWORK_REF compile
   frg-truffle --network $NETWORK_REF compile
 
   echo "Deploying contracts"

--- a/truffle.js
+++ b/truffle.js
@@ -2,14 +2,6 @@ module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // for more about customizing your Truffle configuration!
   networks: {
-    ganacheDev: {
-      ref: 'ganache-dev',
-      host: '127.0.0.1',
-      port: 7545,
-      gas: 7989556,
-      gasPrice: 9000000000,
-      network_id: '*'
-    },
     ganacheUnitTest: {
       ref: 'ganache-unit-test',
       host: '127.0.0.1',
@@ -17,16 +9,6 @@ module.exports = {
       gas: 7989556,
       gasPrice: 9000000000,
       network_id: '*'
-    },
-    gethDev: {
-      ref: 'geth-dev',
-      host: '127.0.0.1',
-      port: 7550,
-      wsPort: 7551,
-      gas: 7989556,
-      gasPrice: 9000000000,
-      network_id: '1234',
-      passcode: 'fragments'
     },
     gethUnitTest: {
       ref: 'geth-unit-test',


### PR DESCRIPTION
Removed `market-oracle` dependency from `uFragments`. 

The dev deployment scripts have been moved to [this](https://github.com/frgprotocol/uFragments-sre) SRE repo.

Modified the `genDummyData` script to run on the `gethUnitTest` environment and not `gethDev`. Everything should work the same, except you need to run `npm run blockchain:start gethUnitTest` and NOT `npm run blockchain:start gethDev`.  

@brandoniles  @truncs 

