### PR TITLE
Fixed hd wallet initialization 

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -16,7 +16,7 @@ module.exports = {
       gasPrice: gethUnitTestConf.gasPrice,
       provider: new HDWalletProvider(
         gethUnitTestConf.testOnlyHDWPasscode,
-        `http://${gethUnitTestConf.host}:${gethUnitTestConf.port}/`, 0)
+        `http://${gethUnitTestConf.host}:${gethUnitTestConf.port}/`, 0, 10)
     },
     ganacheUnitTest: {
       ref: ganacheUnitTestConf.ref,


### PR DESCRIPTION
Initializing 10 HD wallet addresses (defaults to 1 if not specified `accounts[1]` doesn't isn't defined) 