### PR TITLE
Added back 'stochasm' dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5932,6 +5932,12 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stochasm": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/stochasm/-/stochasm-0.5.0.tgz",
+      "integrity": "sha1-JVUX1BbAQTZSGIrwxsgQk/GzP2g=",
+      "dev": true
+    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "request-promise": "^4.2.2",
     "sinon": "^4.5.0",
     "solhint": "^1.1.10",
+    "stochasm": "^0.5.0",
     "util": "^0.11.0",
     "webpack": "^4.10.2",
     "zos-lib": "^1.3.0"


### PR DESCRIPTION
`stochasm` was erroneously removed as part of [this](https://github.com/frgprotocol/uFragments/pull/36) PR. However, this package is used by `frg_necessary_conditions.js` causing the [latest build](https://travis-ci.com/frgprotocol/uFragments/builds/81875177) to fail.




