### PR TITLE
revert on transfer when recepient is the contract address

### DIFF
--- a/contracts/UFragments.sol
+++ b/contracts/UFragments.sol
@@ -68,6 +68,12 @@ contract UFragments is DetailedERC20, Ownable {
         _;
     }
 
+    modifier validRecipient(address to) {
+        require(to != address(0x0));
+        require(to != address(this));
+        _;
+    }
+
     mapping(address => uint256) private gonBalances;
 
     // Use max uint256 to get highest granularity
@@ -236,9 +242,7 @@ contract UFragments is DetailedERC20, Ownable {
      * @dev Transfers a number of gons between from and to, such that the resulting balances match
      * the expectations when denominated in fragments.
      */
-    function transferHelper(address from, address to, uint256 value) private {
-        require(to != address(0));
-
+    function transferHelper(address from, address to, uint256 value) private validRecipient(to) {
         uint256 senderMod = gonBalances[from] % gonsPerFragment;
         uint256 receiverMod = gonBalances[to] % gonsPerFragment;
         uint256 baseAmt = value.mul(gonsPerFragment);

--- a/test/unit/UFragments.js
+++ b/test/unit/UFragments.js
@@ -3,6 +3,8 @@ const _require = require('app-root-path').require;
 const BlockchainCaller = _require('/util/blockchain_caller');
 const chain = new BlockchainCaller(web3);
 const encodeCall = require('zos-lib/lib/helpers/encodeCall').default;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const transferAmount = 10;
 
 let uFragments, b, r, deployer;
 async function setupContracts () {
@@ -290,6 +292,31 @@ contract('UFragments:Transfer', function (accounts) {
       expect(b.toNumber()).to.eq(0);
       b = await uFragments.balanceOf.call(C);
       expect(b.toNumber()).to.eq(973);
+    });
+  });
+
+  describe('when the recipient is the zero address', function () {
+    const to = ZERO_ADDRESS;
+    const owner = A;
+
+    it('reverts on transfer', async function () {
+      await chain.expectEthException(uFragments.transfer(to, transferAmount, { from: owner }));
+    });
+
+    it('reverts on transferFrom', async function () {
+      await chain.expectEthException(uFragments.transferFrom(owner, to, transferAmount, { from: owner }));
+    });
+  });
+
+  describe('when the recipient address is the contract address', function () {
+    const owner = A;
+
+    it('reverts on transfer', async function () {
+      await chain.expectEthException(uFragments.transfer(uFragments.address, transferAmount, { from: owner }));
+    });
+
+    it('reverts on transferFrom', async function () {
+      await chain.expectEthException(uFragments.transferFrom(owner, uFragments.address, transferAmount, { from: owner }));
     });
   });
 });

--- a/test/unit/erc20_behavior.js
+++ b/test/unit/erc20_behavior.js
@@ -85,14 +85,6 @@ contract('UFragments:ERC20', function (accounts) {
         });
       });
     });
-
-    describe('when the recipient is the zero address', function () {
-      const to = ZERO_ADDRESS;
-
-      it('reverts', async function () {
-        await chain.expectEthException(token.transfer(to, 10, { from: owner }));
-      });
-    });
   });
 
   describe('transfer from', function () {
@@ -160,19 +152,6 @@ contract('UFragments:ERC20', function (accounts) {
             await chain.expectEthException(token.transferFrom(owner, to, amount, { from: spender }));
           });
         });
-      });
-    });
-
-    describe('when the recipient is the zero address', function () {
-      const amount = transferAmount;
-      const to = ZERO_ADDRESS;
-
-      beforeEach(async function () {
-        await token.approve(spender, amount, { from: owner });
-      });
-
-      it('reverts', async function () {
-        await chain.expectEthException(token.transferFrom(owner, to, amount, { from: spender }));
       });
     });
   });


### PR DESCRIPTION
https://consensys.github.io/smart-contract-best-practices/tokens/#prevent-transferring-tokens-to-the-contract-address