### PR TITLE
Sync w/ latest approval conventions

### DIFF
--- a/contracts/UFragments.sol
+++ b/contracts/UFragments.sol
@@ -137,6 +137,8 @@ contract UFragments is DetailedERC20, Ownable {
         totalSupply_ = 50000000;  // 50M
         gonBalances[owner] = GONS;
         gonsPerFragment = GONS.div(totalSupply_);
+
+        emit Transfer(address(0x0), owner, totalSupply_);
     }
 
     /**
@@ -199,6 +201,8 @@ contract UFragments is DetailedERC20, Ownable {
      * @param value The amount of tokens to be spent.
      */
     function approve(address spender, uint256 value) public whenTokenNotPaused returns (bool) {
+        require(spender != address(0x0));
+
         allowedFragments[msg.sender][spender] = value;
         emit Approval(msg.sender, spender, value);
         return true;
@@ -214,7 +218,9 @@ contract UFragments is DetailedERC20, Ownable {
      * @param spender The address which will spend the funds.
      * @param addedValue The amount of tokens to increase the allowance by.
      */
-    function increaseApproval(address spender, uint256 addedValue) public whenTokenNotPaused returns (bool) {
+    function increaseAllowance(address spender, uint256 addedValue) public whenTokenNotPaused returns (bool) {
+        require(spender != address(0x0));
+
         allowedFragments[msg.sender][spender] = allowedFragments[msg.sender][spender].add(addedValue);
         emit Approval(msg.sender, spender, allowedFragments[msg.sender][spender]);
         return true;
@@ -230,7 +236,9 @@ contract UFragments is DetailedERC20, Ownable {
      * @param spender The address which will spend the funds.
      * @param subtractedValue The amount of tokens to decrease the allowance by.
      */
-    function decreaseApproval(address spender, uint256 subtractedValue) public whenTokenNotPaused returns (bool) {
+    function decreaseAllowance(address spender, uint256 subtractedValue) public whenTokenNotPaused returns (bool) {
+        require(spender != address(0x0));
+
         uint256 oldValue = allowedFragments[msg.sender][spender];
         if (subtractedValue >= oldValue) {
             allowedFragments[msg.sender][spender] = 0;

--- a/test/unit/UFragments.js
+++ b/test/unit/UFragments.js
@@ -124,12 +124,12 @@ contract('UFragments:PauseRebase', function (accounts) {
     await uFragments.transferFrom(deployer, B, 10, {from: A});
   });
 
-  it('should allow calling increaseApproval', async function () {
-    await uFragments.increaseApproval(A, 10, {from: deployer});
+  it('should allow calling increaseAllowance', async function () {
+    await uFragments.increaseAllowance(A, 10, {from: deployer});
   });
 
-  it('should allow calling decreaseApproval', async function () {
-    await uFragments.decreaseApproval(A, 10, {from: deployer});
+  it('should allow calling decreaseAllowance', async function () {
+    await uFragments.decreaseAllowance(A, 10, {from: deployer});
   });
 
   it('should allow calling balanceOf', async function () {
@@ -201,15 +201,15 @@ contract('UFragments:PauseToken', function (accounts) {
     ).to.be.true;
   });
 
-  it('should not allow calling increaseApproval', async function () {
+  it('should not allow calling increaseAllowance', async function () {
     expect(
-      await chain.isEthException(uFragments.increaseApproval(A, 10, {from: deployer}))
+      await chain.isEthException(uFragments.increaseAllowance(A, 10, {from: deployer}))
     ).to.be.true;
   });
 
-  it('should not allow calling decreaseApproval', async function () {
+  it('should not allow calling decreaseAllowance', async function () {
     expect(
-      await chain.isEthException(uFragments.decreaseApproval(A, 10, {from: deployer}))
+      await chain.isEthException(uFragments.decreaseAllowance(A, 10, {from: deployer}))
     ).to.be.true;
   });
 

--- a/test/unit/erc20_behavior.js
+++ b/test/unit/erc20_behavior.js
@@ -242,24 +242,10 @@ contract('UFragments:ERC20', function (accounts) {
     });
 
     describe('when the spender is the zero address', function () {
-      const amount = transferAmount;
-      const spender = ZERO_ADDRESS;
-
-      it('approves the requested amount', async function () {
-        await token.approve(spender, amount, { from: owner });
-
-        const allowance = await token.allowance(owner, spender);
-        assert.equal(allowance, amount);
-      });
-
-      it('emits an approval event', async function () {
-        const { logs } = await token.approve(spender, amount, { from: owner });
-
-        assert.equal(logs.length, 1);
-        assert.equal(logs[0].event, 'Approval');
-        assert.equal(logs[0].args.owner, owner);
-        assert.equal(logs[0].args.spender, spender);
-        assert(logs[0].args.value.eq(amount));
+      it('should fail', async function () {
+        expect(
+          await chain.isEthException(token.approve(ZERO_ADDRESS, transferAmount, { from: owner }))
+        ).to.be.true;
       });
     });
   });
@@ -276,7 +262,7 @@ contract('UFragments:ERC20', function (accounts) {
         const amount = transferAmount;
 
         it('emits an approval event', async function () {
-          const { logs } = await token.decreaseApproval(spender, amount, { from: owner });
+          const { logs } = await token.decreaseAllowance(spender, amount, { from: owner });
 
           assert.equal(logs.length, 1);
           assert.equal(logs[0].event, 'Approval');
@@ -287,7 +273,7 @@ contract('UFragments:ERC20', function (accounts) {
 
         describe('when there was no approved amount before', function () {
           it('keeps the allowance to zero', async function () {
-            await token.decreaseApproval(spender, amount, { from: owner });
+            await token.decreaseAllowance(spender, amount, { from: owner });
 
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance, 0);
@@ -300,7 +286,7 @@ contract('UFragments:ERC20', function (accounts) {
           });
 
           it('decreases the spender allowance subtracting the requested amount', async function () {
-            await token.decreaseApproval(spender, amount, { from: owner });
+            await token.decreaseAllowance(spender, amount, { from: owner });
 
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance, 1);
@@ -312,7 +298,7 @@ contract('UFragments:ERC20', function (accounts) {
         const amount = erroneousAmount;
 
         it('emits an approval event', async function () {
-          const { logs } = await token.decreaseApproval(spender, amount, { from: owner });
+          const { logs } = await token.decreaseAllowance(spender, amount, { from: owner });
 
           assert.equal(logs.length, 1);
           assert.equal(logs[0].event, 'Approval');
@@ -323,7 +309,7 @@ contract('UFragments:ERC20', function (accounts) {
 
         describe('when there was no approved amount before', function () {
           it('keeps the allowance to zero', async function () {
-            await token.decreaseApproval(spender, amount, { from: owner });
+            await token.decreaseAllowance(spender, amount, { from: owner });
 
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance, 0);
@@ -336,7 +322,7 @@ contract('UFragments:ERC20', function (accounts) {
           });
 
           it('decreases the spender allowance subtracting the requested amount', async function () {
-            await token.decreaseApproval(spender, amount, { from: owner });
+            await token.decreaseAllowance(spender, amount, { from: owner });
 
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance, 1);
@@ -346,28 +332,10 @@ contract('UFragments:ERC20', function (accounts) {
     });
 
     describe('when the spender is the zero address', function () {
-      const amount = transferAmount;
-      const spender = ZERO_ADDRESS;
-
-      beforeEach(async () => {
-        await token.approve(spender, 0, { from: owner });
-      });
-
-      it('decreases the requested amount', async function () {
-        await token.decreaseApproval(spender, amount, { from: owner });
-
-        const allowance = await token.allowance(owner, spender);
-        assert.equal(allowance, 0);
-      });
-
-      it('emits an approval event', async function () {
-        const { logs } = await token.decreaseApproval(spender, amount, { from: owner });
-
-        assert.equal(logs.length, 1);
-        assert.equal(logs[0].event, 'Approval');
-        assert.equal(logs[0].args.owner, owner);
-        assert.equal(logs[0].args.spender, spender);
-        assert(logs[0].args.value.eq(0));
+      it('should fail', async function () {
+        expect(
+          await chain.isEthException(token.decreaseAllowance(ZERO_ADDRESS, transferAmount, { from: owner }))
+        ).to.be.true;
       });
     });
   });
@@ -384,7 +352,7 @@ contract('UFragments:ERC20', function (accounts) {
 
       describe('when the sender has enough balance', function () {
         it('emits an approval event', async function () {
-          const { logs } = await token.increaseApproval(spender, amount, { from: owner });
+          const { logs } = await token.increaseAllowance(spender, amount, { from: owner });
 
           assert.equal(logs.length, 1);
           assert.equal(logs[0].event, 'Approval');
@@ -395,7 +363,7 @@ contract('UFragments:ERC20', function (accounts) {
 
         describe('when there was no approved amount before', function () {
           it('approves the requested amount', async function () {
-            await token.increaseApproval(spender, amount, { from: owner });
+            await token.increaseAllowance(spender, amount, { from: owner });
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance.toNumber(), amount);
           });
@@ -407,7 +375,7 @@ contract('UFragments:ERC20', function (accounts) {
           });
 
           it('increases the spender allowance adding the requested amount', async function () {
-            await token.increaseApproval(spender, amount, { from: owner });
+            await token.increaseAllowance(spender, amount, { from: owner });
 
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance, amount + 1);
@@ -419,7 +387,7 @@ contract('UFragments:ERC20', function (accounts) {
         const amount = erroneousAmount;
 
         it('emits an approval event', async function () {
-          const { logs } = await token.increaseApproval(spender, amount, { from: owner });
+          const { logs } = await token.increaseAllowance(spender, amount, { from: owner });
 
           assert.equal(logs.length, 1);
           assert.equal(logs[0].event, 'Approval');
@@ -430,7 +398,7 @@ contract('UFragments:ERC20', function (accounts) {
 
         describe('when there was no approved amount before', function () {
           it('approves the requested amount', async function () {
-            await token.increaseApproval(spender, amount, { from: owner });
+            await token.increaseAllowance(spender, amount, { from: owner });
 
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance.toNumber(), amount);
@@ -443,7 +411,7 @@ contract('UFragments:ERC20', function (accounts) {
           });
 
           it('increases the spender allowance adding the requested amount', async function () {
-            await token.increaseApproval(spender, amount, { from: owner });
+            await token.increaseAllowance(spender, amount, { from: owner });
 
             const allowance = await token.allowance(owner, spender);
             assert.equal(allowance, amount + 1);
@@ -453,27 +421,10 @@ contract('UFragments:ERC20', function (accounts) {
     });
 
     describe('when the spender is the zero address', function () {
-      const spender = ZERO_ADDRESS;
-
-      beforeEach(async () => {
-        await token.approve(spender, 0, { from: owner });
-      });
-
-      it('approves the requested amount', async function () {
-        await token.increaseApproval(spender, amount, { from: owner });
-
-        const allowance = await token.allowance(owner, spender);
-        assert.equal(allowance, amount);
-      });
-
-      it('emits an approval event', async function () {
-        const { logs } = await token.increaseApproval(spender, amount, { from: owner });
-
-        assert.equal(logs.length, 1);
-        assert.equal(logs[0].event, 'Approval');
-        assert.equal(logs[0].args.owner, owner);
-        assert.equal(logs[0].args.spender, spender);
-        assert(logs[0].args.value.eq(amount));
+      it('should fail', async function () {
+        expect(
+          await chain.isEthException(token.increaseAllowance(ZERO_ADDRESS, amount, { from: owner }))
+        ).to.be.true;
       });
     });
   });


### PR DESCRIPTION
OpenZeppelin is moving to different naming conventions for increase/decrease approval. These aren't part of any ERC spec, so I think it's safer to go with the names and conventions that will be most used.