### PR TITLE
Represent GonsPerFragment as an exact number

### DIFF
--- a/contracts/UFragments.sol
+++ b/contracts/UFragments.sol
@@ -131,7 +131,7 @@ contract UFragments is DetailedERC20, Ownable {
             _totalSupply = MAX_SUPPLY.sub(1);
         }
 
-        // _gonsPerFragment is considered an exact value. such that
+        // _gonsPerFragment is considered an exact value, such that
         // _gonsPerFragment can convert bidirectionally with no rounding errors.
         // If there is a remainder to this division, the precision loss is
         // assumed to be in _totalSupply and it can be up to
@@ -189,7 +189,8 @@ contract UFragments is DetailedERC20, Ownable {
      * @param value The amount to be transferred.
      * @return True on success, false otherwise.
      */
-    function transfer(address to, uint256 value) public
+    function transfer(address to, uint256 value)
+        public
         validRecipient(to)
         whenTokenNotPaused
         returns (bool)
@@ -217,7 +218,8 @@ contract UFragments is DetailedERC20, Ownable {
      * @param to The address you want to transfer to.
      * @param value The amount of tokens to be transferred.
      */
-    function transferFrom(address from, address to, uint256 value) public
+    function transferFrom(address from, address to, uint256 value)
+        public
         validRecipient(to)
         whenTokenNotPaused
         returns (bool)
@@ -245,6 +247,7 @@ contract UFragments is DetailedERC20, Ownable {
      */
     function approve(address spender, uint256 value) public whenTokenNotPaused returns (bool) {
         require(spender != address(0x0));
+
         _allowedFragments[msg.sender][spender] = value;
         emit Approval(msg.sender, spender, value);
         return true;


### PR DESCRIPTION
Compute GonsPerFragment value and consider it exact. And adjust totalSupply accordingly, this in theory result in a different totalSupply than the requested.

P.S.:Practically Speaking for any reasonable value of totalSupply .i.e, totalSupply < what is representable in 128-bits, the adjustment is a no-op. 
as the difference is at most: GONS / (GonsPerFragment^2 + GonsPerFragment)

The critical part of this change is making the initial TotalsGONS a multiple of the initial Supply. to never have unaccounted for GONS. This ensures that the fraction of a what a wallet owns from total GONS in circulation never changes or gets affected by rounding.